### PR TITLE
feat: add logging system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules/
 /prod/
 .env
+
+## Don't commit actual log files
+/logs/*.txt

--- a/logs/.gitkeep
+++ b/logs/.gitkeep
@@ -1,0 +1,1 @@
+Need this empty directory for the log files to write to.

--- a/src/commands/tickets/close.ts
+++ b/src/commands/tickets/close.ts
@@ -7,6 +7,7 @@ import {
 
 import { BotInt } from "../../interfaces/BotInt";
 import { ButtonHandler } from "../../interfaces/ButtonHandler";
+import { generateLogs } from "../../modules/generateLogs";
 import { errorHandler } from "../../utils/errorHandler";
 
 /**
@@ -20,7 +21,7 @@ export const closeHandler: ButtonHandler = async (Bot, interaction) => {
     await interaction.deferReply({ ephemeral: true });
     const { guild, member, channel } = interaction;
 
-    if (!guild || !member) {
+    if (!guild || !member || !channel) {
       await interaction.editReply({
         content: "Error finding the guild!",
       });
@@ -50,8 +51,10 @@ export const closeHandler: ButtonHandler = async (Bot, interaction) => {
       "User",
       (channel as TextChannel)?.name.split("-").slice(1).join("-") || "unknown"
     );
-    await Bot.logHook.send({ embeds: [logEmbed] });
-    await interaction.channel?.delete();
+
+    const logFile = await generateLogs(Bot, channel.id);
+    await Bot.logHook.send({ embeds: [logEmbed], files: [logFile] });
+    await channel.delete();
   } catch (err) {
     errorHandler("close handler", err);
   }

--- a/src/commands/tickets/ticket.ts
+++ b/src/commands/tickets/ticket.ts
@@ -9,6 +9,7 @@ import {
 
 import { BotInt } from "../../interfaces/BotInt";
 import { ButtonHandler } from "../../interfaces/ButtonHandler";
+import { createLogFile } from "../../modules/createLogFile";
 import { errorHandler } from "../../utils/errorHandler";
 
 /**
@@ -91,6 +92,8 @@ export const ticketHandler: ButtonHandler = async (Bot, interaction) => {
     ticketEmbed.setDescription(
       `<@!${user.id}>, here is your private ticket channel!`
     );
+
+    await createLogFile(Bot, ticketChannel.id);
 
     await ticketChannel.send({ embeds: [ticketEmbed], components: [row] });
     await interaction.editReply(

--- a/src/events/onMessage.ts
+++ b/src/events/onMessage.ts
@@ -1,0 +1,32 @@
+import { Message } from "discord.js";
+
+import { BotInt } from "../interfaces/BotInt";
+import { logMessage } from "../modules/logMessage";
+import { errorHandler } from "../utils/errorHandler";
+
+/**
+ * Handles the message create event from Discord, checks if the message is in
+ * an active ticket, and if so, log it.
+ *
+ * @param {BotInt} Bot The bot's Discord instance.
+ * @param {Message} message The message payload from Discord.
+ */
+export const onMessage = async (
+  Bot: BotInt,
+  message: Message
+): Promise<void> => {
+  try {
+    if (message.author.bot) {
+      return;
+    }
+    const id = message.channelId;
+
+    if (!Bot.ticketLogs[id]) {
+      return;
+    }
+
+    await logMessage(Bot, message, Bot.ticketLogs[id]);
+  } catch (err) {
+    errorHandler("message event", err);
+  }
+};

--- a/src/interfaces/BotInt.ts
+++ b/src/interfaces/BotInt.ts
@@ -8,4 +8,5 @@ export interface BotInt extends Client {
   botOwner: string;
   category: string;
   supportRole: string;
+  ticketLogs: { [key: string]: string };
 }

--- a/src/modules/createLogFile.ts
+++ b/src/modules/createLogFile.ts
@@ -1,0 +1,27 @@
+import { writeFile } from "fs/promises";
+import { join } from "path";
+
+import { BotInt } from "../interfaces/BotInt";
+import { errorHandler } from "../utils/errorHandler";
+
+/**
+ * Creates the initial ticket log file.
+ *
+ * @param {BotInt} Bot The bot's Discord instance.
+ * @param {string} channelId The ticket channel ID, used as a unique identifier.
+ */
+export const createLogFile = async (
+  Bot: BotInt,
+  channelId: string
+): Promise<void> => {
+  try {
+    Bot.ticketLogs[channelId] = channelId;
+
+    await writeFile(
+      join(process.cwd(), "logs", `${channelId}.txt`),
+      `[${new Date().toLocaleString()}] - **TICKET CREATED**\n`
+    );
+  } catch (err) {
+    errorHandler("log file creation", err);
+  }
+};

--- a/src/modules/generateLogs.ts
+++ b/src/modules/generateLogs.ts
@@ -1,0 +1,45 @@
+import { readFile, unlink } from "fs/promises";
+import { join } from "path";
+
+import { MessageAttachment } from "discord.js";
+
+import { BotInt } from "../interfaces/BotInt";
+import { errorHandler } from "../utils/errorHandler";
+
+/**
+ * To run when a ticket is closed. Finds the ticket log file,
+ * creates a message attachement with the logs, and deletes the file.
+ *
+ * @param {BotInt} Bot The bot's Discord instance.
+ * @param {string} channelId The channel ID of the ticket.
+ * @returns {Promise<MessageAttachment>} The log file as a Discord attachment.
+ */
+export const generateLogs = async (
+  Bot: BotInt,
+  channelId: string
+): Promise<MessageAttachment> => {
+  try {
+    const logName = Bot.ticketLogs[channelId];
+    delete Bot.ticketLogs[channelId];
+
+    const logs = await readFile(
+      join(process.cwd(), "logs", `${logName}.txt`),
+      "utf8"
+    ).catch(() => "no logs found...");
+
+    const attachment = new MessageAttachment(
+      Buffer.from(logs, "utf-8"),
+      "log.txt"
+    );
+
+    await unlink(join(process.cwd(), "logs", `${logName}.txt`));
+
+    return attachment;
+  } catch (err) {
+    errorHandler("log generator", err);
+    return new MessageAttachment(
+      Buffer.from("An error occurred fetching these logs.", "utf-8"),
+      "log.txt"
+    );
+  }
+};

--- a/src/modules/handleEvents.ts
+++ b/src/modules/handleEvents.ts
@@ -1,4 +1,5 @@
 import { onInteractionCreate } from "../events/onInteractionCreate";
+import { onMessage } from "../events/onMessage";
 import { onReady } from "../events/onReady";
 import { BotInt } from "../interfaces/BotInt";
 
@@ -12,6 +13,8 @@ export const handleEvents = (Bot: BotInt): void => {
     "interactionCreate",
     async (interaction) => await onInteractionCreate(Bot, interaction)
   );
+
+  Bot.on("messageCreate", async (message) => await onMessage(Bot, message));
 
   Bot.on("ready", async () => await onReady(Bot));
 };

--- a/src/modules/logMessage.ts
+++ b/src/modules/logMessage.ts
@@ -1,0 +1,38 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+import { Message } from "discord.js";
+
+import { BotInt } from "../interfaces/BotInt";
+import { errorHandler } from "../utils/errorHandler";
+
+/**
+ * Logs messages to a file to track ticket activity.
+ *
+ * @param {BotInt} Bot The bot's Discord instance.
+ * @param {Message} message The Discord message payload.
+ * @param {string} logId The logId to identify the file.
+ */
+export const logMessage = async (
+  Bot: BotInt,
+  message: Message,
+  logId: string
+): Promise<void> => {
+  try {
+    const logFile = await readFile(
+      join(process.cwd(), "logs", `${logId}.txt`),
+      "utf8"
+    );
+
+    const parsedString = `[${new Date(
+      message.createdTimestamp
+    ).toLocaleString()}] - ${message.author.tag}: ${message.content}\n`;
+
+    await writeFile(
+      join(process.cwd(), "logs", `${logId}.txt`),
+      logFile + parsedString
+    );
+  } catch (err) {
+    errorHandler("message logger", err);
+  }
+};

--- a/src/modules/validateEnv.ts
+++ b/src/modules/validateEnv.ts
@@ -24,6 +24,7 @@ export const validateEnv = (Bot: BotInt): boolean => {
   Bot.botOwner = botOwner;
   Bot.category = category;
   Bot.supportRole = supportRole;
+  Bot.ticketLogs = {};
 
   return true;
 };


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Adds the logic to generate text logs for ticket interactions, storing those logs temporarily until the ticket is closed, then sending those logs with the close embed.

This will allow us to store ticket details on platform (which Discord prefers), and we'll be able to refer to logs if anyone files a complaint.
<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
